### PR TITLE
fix runtime error on simple-viewer-set-key!

### DIFF
--- a/lib/gl/simple/viewer.scm
+++ b/lib/gl/simple/viewer.scm
@@ -399,7 +399,7 @@
 
 (define (simple-viewer-set-key! window . args)
   (let1 tab (cond [(not window) *default-key-handlers*]
-                  [(name->window window) => (cut ref <> 'key-handlers)]
+                  [(name->window window) => (^[win] ((ref win'closure) 'key-handlers))]
                   [else
                    (error "simple-viewer-set-key!: no such window:" window)])
     (let loop ([args args])


### PR DESCRIPTION
got an error when I called simple-viewer-set-key!

```
*** ERROR: object of class #<class <simple-viewer-window>> doesn't have such slot: key-handlers
```

Does this fix work?
