### PR TITLE
Change for MinGW (32bit)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -122,10 +122,18 @@ AC_CHECK_PROGS(GZIP_PROGRAM, gzip)
 
 # Check for libraries
 
-# on cygwin, we need several extra -l flags.
+# On Cygwin or MinGW, we need several extra -l flags.
 case "$target" in
   *-*-cygwin*|*-*-mingw*)
-    LIBS="-lgauche-uvector $LIBS"
+    # Gauche's uvector library file name is changed in v0.9.5_pre1.
+    GAUCHE_SYSDIR=`"$GAUCHE_CONFIG" --sysarchdir | sed 's/\\\\/\\//g'`
+    GAUCHE_UVECTOR_DLL="$GAUCHE_SYSDIR/gauche--uvector.$SOEXT"
+    if test -e "$GAUCHE_UVECTOR_DLL"; then
+        GAUCHE_UVECTOR_LIBS="-lgauche--uvector"
+    else
+        GAUCHE_UVECTOR_LIBS="-lgauche-uvector"
+    fi
+    LIBS="$GAUCHE_UVECTOR_LIBS $LIBS"
     GL_EXTRALIBS="-L. -lgauche-math3d"
     GLUT_EXTRALIBS="-L. -lgauche-gl -lgauche-math3d"
     ;;

--- a/examples/glbook/example7-2.scm
+++ b/examples/glbook/example7-2.scm
@@ -26,6 +26,7 @@
   (gl-end))
 
 (define (disp)
+  (gl-load-identity)
   (gl-clear GL_COLOR_BUFFER_BIT)
   (gl-color 0.0 1.0 0.0)
   (dotimes (i 10) (gl-call-list *list-name*))

--- a/src/gl-lib.scm
+++ b/src/gl-lib.scm
@@ -477,17 +477,17 @@
     (unless (and (SCM_F32VECTORP v2) (== (SCM_F32VECTOR_SIZE v2) 2))
       (goto badarg2))
     (glRectfv (SCM_F32VECTOR_ELEMENTS v1) (SCM_F32VECTOR_ELEMENTS v2))]
-   [(SCM_F64VECTOR_SIZE v1)
+   [(SCM_F64VECTORP v1)
     (unless (== (SCM_F64VECTOR_SIZE v1) 2) (goto badarg1))
     (unless (and (SCM_F64VECTORP v2) (== (SCM_F64VECTOR_SIZE v2) 2))
       (goto badarg2))
     (glRectdv (SCM_F64VECTOR_ELEMENTS v1) (SCM_F64VECTOR_ELEMENTS v2))]
-   [(SCM_S32VECTOR_SIZE v1)
+   [(SCM_S32VECTORP v1)
     (unless (== (SCM_S32VECTOR_SIZE v1) 2) (goto badarg1))
     (unless (and (SCM_S32VECTORP v2) (== (SCM_S32VECTOR_SIZE v2) 2))
       (goto badarg2))
     (glRectiv (SCM_S32VECTOR_ELEMENTS v1) (SCM_S32VECTOR_ELEMENTS v2))]
-   [(SCM_S16VECTOR_SIZE v1)
+   [(SCM_S16VECTORP v1)
     (unless (== (SCM_S16VECTOR_SIZE v1) 2) (goto badarg1))
     (unless (and (SCM_S16VECTORP v2) (== (SCM_S16VECTOR_SIZE v2) 2))
       (goto badarg2))


### PR DESCRIPTION
1. Gauche's uvector library file name is changed in v0.9.5_pre1.
     configure.ac

2. gl-rect error fix.
     src/gl-lib.stub

3. GLEW Initialization fix.
   When using GLEW, 'glewInit' must be called after 'glutCreateWindow'
   to use OpenGL extensions such as 'glTexImage3D'.
   Thus, 'glewInit' was moved to 'glut-create-window'.
     src/glut-lib.stub

4. demo fix.
   When a demo window is clicked, drawing contents are moved to the right direction.
     examples/glbook/example7-2.scm
