### PR TITLE
Fix GLEW initialize

### DIFF
--- a/src/glut-lib.scm
+++ b/src/glut-lib.scm
@@ -59,11 +59,21 @@
     (when (< argc 0) (SCM_TYPE_ERROR args "list"))
     (set! argv (Scm_ListToCStringArray args TRUE NULL))
     (glutInit (& argc) argv)
-    (.if "defined(HAVE_GL_GLEW_H)"
-         (let* ([r::GLenum (glewInit)])
-           (unless (!= r GLEW_OK)
-             (Scm_Error "Initializing GLEW failed."))))
+    ;; The following code was moved to 'glut-create-window',
+    ;; because 'glewInit' must be called after 'glutCreateWindow'
+    ;; to use OpenGL extensions (e.g. 'glTexImage3D').
+    ;(.if "defined(HAVE_GL_GLEW_H)"
+    ;     (let* ([r::GLenum (glewInit)])
+    ;       (if (!= r GLEW_OK)
+    ;         (Scm_Error "Initializing GLEW failed."))))
     (result (Scm_CStringArrayToList (cast (const char**) argv) argc 0))))
+
+;; For debug
+(define-cproc glew-init () ::<void>
+  (.if "defined(HAVE_GL_GLEW_H)"
+       (let* ([r::GLenum (glewInit)])
+         (if (!= r GLEW_OK)
+           (Scm_Error "Initializing GLEW failed.")))))
 
 (define-cproc glut-init-display-mode (mode::<fixnum>)
   ::<void> glutInitDisplayMode)
@@ -82,8 +92,13 @@
 
 (define-cproc glut-main-loop () ::<void> glutMainLoop)
 
-(define-cproc glut-create-window (name::<const-cstring>)
-  ::<int> glutCreateWindow)
+(define-cproc glut-create-window (name::<const-cstring>) ::<int>
+  (let* ([r1::int (glutCreateWindow name)])
+    (.if "defined(HAVE_GL_GLEW_H)"
+         (let* ([r::GLenum (glewInit)])
+           (if (!= r GLEW_OK)
+             (Scm_Error "Initializing GLEW failed."))))
+    (result r1)))
 
 (define-cproc glut-create-sub-window (win::<int> x::<int> y::<int>
                                       width::<int> height::<int>)


### PR DESCRIPTION
1. GLEWの初期化エラーの修正  
   glewInit は glutCreateWindow の後で呼び出す必要がある。  
   http://glew.sourceforge.net/basic.html  
   http://stackoverflow.com/questions/24245481/glteximage3d-throws-exception  
   これが原因で、examples/glbook/example9-4.scm の gl-tex-image-3d の呼び出しでエラーになっていた。  
   (OpenGLの拡張機能が使えなくなっていた)
   - src/glut-lib.scm
