### PR TITLE
Fix glut-font

### DIFF
--- a/src/gauche-glut.c
+++ b/src/gauche-glut.c
@@ -306,6 +306,8 @@ void Scm_Init_libgauche_glut(void)
     ScmModule *mod;
     SCM_INIT_EXTENSION(libgauche_glut);
     mod = SCM_MODULE(SCM_FIND_MODULE("gl.glut", TRUE));
+    Scm_InitStaticClass(&Scm_GlutFontClass, "<glut-font>",
+                        mod, NULL, 0);
     Scm_Init_glut_lib(mod);
 
     /* Callback table */


### PR DESCRIPTION
1. 以下を実行すると Segmentation Fault エラーになる件を修正
   
   ```
   (use gl)
   (use gl.glut)
   (d GLUT_STROKE_ROMAN)
   ```
   - src/gauche-glut.c
