### PR TITLE
Add sse options to avoid math3d test errors on MSYS2/MinGW-w64 32bit

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -9,6 +9,13 @@ AC_CANONICAL_SYSTEM
 
 AC_PATH_XTRA
 
+# On MSYS2/MinGW-w64 32bit, we must add sse options in order to avoid
+# math3d test errors.
+case "$target" in
+  i686-*-mingw*)
+    CFLAGS="$CFLAGS -msse2 -mfpmath=sse";;
+esac
+
 case "$target" in
   *-*-cygwin*)
     if test "x-$have_x" = "x-disabled" -o "x-$have_x" = "x-no";


### PR DESCRIPTION
- MSYS2/MinGW-w64 32bit 環境で、math3d のテストがエラーになったため、
  configure.ac 内で SSE 使用のオプションを追加するようにしました。

- make check で 以下のエラーが出ていました。
  ```
  discrepancies found.  Errors are:
  test 2vtest #,(vector4f 1 1 0 0) #,(vector4f 1 1 0 0): expects #,(vector4f 0.707107 0.707107 0 0) => got #,(vector4f 0.707292 0.706922 0 0)
  test 2vtest #,(vector4f 1 1 0 0) #,(vector4f 1 1 0 0): expects #,(vector4f 0.707107 0.707107 0 0) => got #,(vector4f 0.707292 0.706922 0 0)
  ```

- 多分また 387 の 80bit 浮動小数点数演算の関係だと思います(詳しくは調べていませんが。。。)。

- 少し前に MSYS2 を更新したのですが、更新前は問題ありませんでした。
  (古い test.log が残っていたので確認しました)


＜テスト結果＞
OS : Windows 8.1 (64bit)
Gauche : コミット a2a9673 + 本変更

開発環境1 : MSYS2/MinGW-w64 (64bit) (gcc version 6.3.0 (Rev2, Built by MSYS2 project))
make check - OK
サンプルプログラムの起動 - OK

開発環境2 : MSYS2/MinGW-w64 (32bit) (gcc version 6.3.0 (Rev2, Built by MSYS2 project))
make check - OK
サンプルプログラムの起動 - OK

開発環境3 : MinGW.org (32bitのみ) (gcc v4.8.1)
make check - OK
サンプルプログラムの起動 - OK
